### PR TITLE
Update pg gem version in gemspec to support latest verstions of the gem

### DIFF
--- a/pg_generated_column_support.gemspec
+++ b/pg_generated_column_support.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "activerecord", "~> 6.1.5"
-  spec.add_dependency "pg", "~> 1.2.3"
+  spec.add_dependency "pg", ">= 1.2.3"
 end


### PR DESCRIPTION
Hello! It works fine for me with `gem "pg", "~> 1.4.3"`. Think that update makes sense. Thank you! 